### PR TITLE
feat: Add custom selection color across app to match branding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -123,6 +123,10 @@
   body {
     @apply bg-background text-foreground font-sans tracking-wide;
   }
+
+  body::selection {
+    @apply bg-foreground text-background;
+  }
 }
 
 .adaptive-icon img {


### PR DESCRIPTION
This PR implements custom selection colors at the `globals.css` level to cover the entire app. It uses inverted branding colors to ensure legibility against background colors in light/dark modes.

Closes #3