### PR TITLE
Update 404 heading to a more casual tone

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -21,7 +21,7 @@ export default function NotFound() {
               </h1>
 
               <h2 className='text-2xl sm:text-3xl font-semibold tracking-tight text-foreground'>
-                Page Not Found
+                You look a little lost
               </h2>
             </div>
           </div>
@@ -29,7 +29,7 @@ export default function NotFound() {
           {/* Description */}
           <div className='max-w-md mx-auto'>
             <p className='text-lg text-muted-foreground leading-relaxed'>
-              Sorry, the page you&apos;re looking for doesn&apos;t exist or has been moved.
+              We all get lost sometimes, and that&apos;s OK. This page doesn&apos;t exist, but there&apos;s plenty more to explore.
             </p>
           </div>
         </div>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -21,7 +21,7 @@ export default function NotFound() {
               </h1>
 
               <h2 className='text-2xl sm:text-3xl font-semibold tracking-tight text-foreground'>
-                You look a little lost
+                Lost? It happens.
               </h2>
             </div>
           </div>


### PR DESCRIPTION
Summary
	∙	Updated the 404 page heading from “Page Not Found” to “Lost? It happens.” for a more casual, human tone
	∙	Replaced the generic description with a warmer message: “We all get lost sometimes, and that’s OK. This page doesn’t exist, but there’s plenty more to explore.”
Test plan
	∙	[ ] Navigate to a non-existent route and verify the updated 404 page copy renders correctly
	∙	[ ] Confirm the page still functions as expected (Go Back, View Projects, Contact Me buttons, quick nav links)